### PR TITLE
協賛企業・団体ページの追加

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1105,6 +1105,98 @@ body.menu-open {
     line-height: 1.6;
 }
 
+/* 協賛ページ */
+.sponsors-intro {
+    text-align: center;
+    font-size: 1.1rem;
+    color: #666;
+    margin-bottom: 3rem;
+    line-height: 1.8;
+}
+
+.sponsors-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.sponsor-card {
+    background: rgba(255, 255, 255, 0.95);
+    padding: 2rem;
+    border-radius: 15px;
+    box-shadow: 0 5px 20px rgba(0,0,0,0.08);
+    border: 1px solid #f5d0da;
+    backdrop-filter: blur(5px);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.sponsor-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 10px 30px rgba(233, 30, 99, 0.1);
+}
+
+.sponsor-name {
+    font-size: 1.1rem;
+    font-weight: 400;
+    color: #333;
+    font-family: 'Noto Serif JP', 'Hiragino Mincho ProN', 'Yu Mincho', 'Meiryo', serif;
+    line-height: 1.5;
+}
+
+.sponsor-links {
+    display: flex;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+}
+
+.sponsor-link {
+    display: inline-block;
+    font-size: 0.85rem;
+    color: #e91e63;
+    text-decoration: none;
+    border: 1px solid #e91e63;
+    padding: 0.3rem 0.9rem;
+    border-radius: 20px;
+    transition: all 0.2s ease;
+}
+
+.sponsor-link:hover {
+    background: #e91e63;
+    color: white;
+}
+
+.sponsors-cta {
+    text-align: center;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.sponsors-cta h2 {
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+}
+
+.sponsors-cta p {
+    font-size: 1.1rem;
+    color: #666;
+    margin-bottom: 1rem;
+    line-height: 1.8;
+}
+
+.sponsors-cta .btn {
+    margin-top: 1.5rem;
+}
+
+@media (max-width: 768px) {
+    .sponsors-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* 活動報告ページ */
 .report-summary {
     display: grid;

--- a/header.html
+++ b/header.html
@@ -11,6 +11,7 @@
         <li><a href="report.html">活動報告</a></li>
         <li><a href="support.html">応援</a></li>
         <li><a href="index.html#membership">会員募集</a></li>
+        <li><a href="sponsors.html">協賛</a></li>
         <li><a href="contact.html">お問い合わせ</a></li>
       </ul>
     </nav>

--- a/sponsors.html
+++ b/sponsors.html
@@ -21,30 +21,26 @@
         <section class="section">
             <div class="container">
                 <h2>2025年度 協賛企業・団体</h2>
-                <p class="sponsors-intro">以下の企業・団体様より、ご協賛をいただいております。心より感謝申し上げます。</p>
+                <p class="sponsors-intro">以下の企業・団体様より、ご協賛をいただいております。心より感謝申し上げます。<br>（五十音順、敬称略）</p>
 
                 <div class="sponsors-grid">
-
-                    <div class="sponsor-card">
-                        <div class="sponsor-name">三協エンジニアリング株式会社</div>
-                        <div class="sponsor-links">
-                            <a href="https://sankyo-engineering.info/" target="_blank" rel="noopener noreferrer" class="sponsor-link">公式サイト</a>
-                        </div>
-                    </div>
-
-                    <div class="sponsor-card">
-                        <div class="sponsor-name">山﨑合同司法書士事務所</div>
-                    </div>
-
-                    <div class="sponsor-card">
-                        <div class="sponsor-name">ノック法律事務所</div>
-                    </div>
 
                     <div class="sponsor-card">
                         <div class="sponsor-name">池辺不動産株式会社</div>
                         <div class="sponsor-links">
                             <a href="https://www.ikebe-i.com/" target="_blank" rel="noopener noreferrer" class="sponsor-link">公式サイト</a>
                         </div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">will hair design</div>
+                        <div class="sponsor-links">
+                            <a href="https://www.instagram.com/will_nanri" target="_blank" rel="noopener noreferrer" class="sponsor-link">Instagram</a>
+                        </div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">株式会社晃安外装</div>
                     </div>
 
                     <div class="sponsor-card">
@@ -56,13 +52,9 @@
                     </div>
 
                     <div class="sponsor-card">
-                        <div class="sponsor-name">株式会社晃安外装</div>
-                    </div>
-
-                    <div class="sponsor-card">
-                        <div class="sponsor-name">will hair design</div>
+                        <div class="sponsor-name">三協エンジニアリング株式会社</div>
                         <div class="sponsor-links">
-                            <a href="https://www.instagram.com/will_nanri" target="_blank" rel="noopener noreferrer" class="sponsor-link">Instagram</a>
+                            <a href="https://sankyo-engineering.info/" target="_blank" rel="noopener noreferrer" class="sponsor-link">公式サイト</a>
                         </div>
                     </div>
 
@@ -71,6 +63,14 @@
                         <div class="sponsor-links">
                             <a href="https://shimekikin.org/" target="_blank" rel="noopener noreferrer" class="sponsor-link">公式サイト</a>
                         </div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">ノック法律事務所</div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">山﨑合同司法書士事務所</div>
                     </div>
 
                 </div>

--- a/sponsors.html
+++ b/sponsors.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>協賛企業・団体 - NPO法人咲良</title>
+    <meta name="description" content="NPO法人咲良の活動を支援してくださっている協賛企業・団体をご紹介します。">
+    <link rel="stylesheet" href="assets/css/styles.css">
+    <link rel="icon" type="image/png" href="assets/images/fabicon.png">
+</head>
+<body>
+    <div id="header"></div>
+    <main>
+        <section class="hero">
+            <div class="container">
+                <h2>協賛企業・団体</h2>
+                <p>咲良の活動を温かくご支援いただいている企業・団体の皆様をご紹介します。</p>
+            </div>
+        </section>
+
+        <section class="section">
+            <div class="container">
+                <h2>2025年度 協賛企業・団体</h2>
+                <p class="sponsors-intro">以下の企業・団体様より、ご協賛をいただいております。心より感謝申し上げます。</p>
+
+                <div class="sponsors-grid">
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">三協エンジニアリング株式会社</div>
+                        <div class="sponsor-links">
+                            <a href="https://sankyo-engineering.info/" target="_blank" rel="noopener noreferrer" class="sponsor-link">公式サイト</a>
+                        </div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">山﨑合同司法書士事務所</div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">ノック法律事務所</div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">池辺不動産株式会社</div>
+                        <div class="sponsor-links">
+                            <a href="https://www.ikebe-i.com/" target="_blank" rel="noopener noreferrer" class="sponsor-link">公式サイト</a>
+                        </div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">株式会社COLRS</div>
+                        <div class="sponsor-links">
+                            <a href="https://www.colors-official.com/company" target="_blank" rel="noopener noreferrer" class="sponsor-link">公式サイト</a>
+                            <a href="https://www.instagram.com/colors_reform" target="_blank" rel="noopener noreferrer" class="sponsor-link">Instagram</a>
+                        </div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">株式会社晃安外装</div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">will hair design</div>
+                        <div class="sponsor-links">
+                            <a href="https://www.instagram.com/will_nanri" target="_blank" rel="noopener noreferrer" class="sponsor-link">Instagram</a>
+                        </div>
+                    </div>
+
+                    <div class="sponsor-card">
+                        <div class="sponsor-name">NPO法人 志免地域支え合い互助基金</div>
+                        <div class="sponsor-links">
+                            <a href="https://shimekikin.org/" target="_blank" rel="noopener noreferrer" class="sponsor-link">公式サイト</a>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </section>
+
+        <section class="section section-alt">
+            <div class="container">
+                <div class="sponsors-cta">
+                    <h2>協賛のご案内</h2>
+                    <p>NPO法人咲良の活動にご賛同いただける企業・団体様のご協賛を募集しております。</p>
+                    <p>詳細については、お問い合わせフォームよりお気軽にご連絡ください。</p>
+                    <a href="contact.html" class="btn btn-primary">お問い合わせはこちら</a>
+                </div>
+            </div>
+        </section>
+    </main>
+    <div id="footer"></div>
+    <script src="assets/js/include.js"></script>
+</body>
+</html>

--- a/sponsors.html
+++ b/sponsors.html
@@ -20,7 +20,7 @@
 
         <section class="section">
             <div class="container">
-                <h2>2025年度 協賛企業・団体</h2>
+                <h2>2026年度 協賛企業・団体</h2>
                 <p class="sponsors-intro">以下の企業・団体様より、ご協賛をいただいております。心より感謝申し上げます。<br>（五十音順、敬称略）</p>
 
                 <div class="sponsors-grid">

--- a/sponsors.html
+++ b/sponsors.html
@@ -6,6 +6,7 @@
     <title>協賛企業・団体 - NPO法人咲良</title>
     <meta name="description" content="NPO法人咲良の活動を支援してくださっている協賛企業・団体をご紹介します。">
     <link rel="stylesheet" href="assets/css/styles.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="icon" type="image/png" href="assets/images/fabicon.png">
 </head>
 <body>
@@ -35,7 +36,7 @@
                     <div class="sponsor-card">
                         <div class="sponsor-name">will hair design</div>
                         <div class="sponsor-links">
-                            <a href="https://www.instagram.com/will_nanri" target="_blank" rel="noopener noreferrer" class="sponsor-link">Instagram</a>
+                            <a href="https://www.instagram.com/will_nanri" target="_blank" rel="noopener noreferrer" class="sponsor-link"><i class="fa-brands fa-instagram"></i> Instagram</a>
                         </div>
                     </div>
 
@@ -47,7 +48,7 @@
                         <div class="sponsor-name">株式会社COLRS</div>
                         <div class="sponsor-links">
                             <a href="https://www.colors-official.com/company" target="_blank" rel="noopener noreferrer" class="sponsor-link">公式サイト</a>
-                            <a href="https://www.instagram.com/colors_reform" target="_blank" rel="noopener noreferrer" class="sponsor-link">Instagram</a>
+                            <a href="https://www.instagram.com/colors_reform" target="_blank" rel="noopener noreferrer" class="sponsor-link"><i class="fa-brands fa-instagram"></i> Instagram</a>
                         </div>
                     </div>
 


### PR DESCRIPTION
## 変更内容

- `sponsors.html` を新規作成（2025年度協賛企業・団体 8社を掲載）
- ナビゲーションに「協賛」リンクを追加
- 協賛ページ用CSSを `styles.css` に追加

## 掲載企業・団体

| 社名 | リンク |
|------|--------|
| 三協エンジニアリング株式会社 | 公式サイト |
| 山﨑合同司法書士事務所 | なし |
| ノック法律事務所 | なし |
| 池辺不動産株式会社 | 公式サイト |
| 株式会社COLRS | 公式サイト・Instagram |
| 株式会社晃安外装 | なし |
| will hair design | Instagram |
| NPO法人 志免地域支え合い互助基金 | 公式サイト |

## 確認事項

- [ ] `sponsors.html` の表示確認
- [ ] ナビゲーションの「協賛」リンク動作確認
- [ ] スマホ表示確認

---
_Generated by [Claude Code](https://claude.ai/code/session_015vCvX4zoe7fhV6C7TB5Db3)_